### PR TITLE
replace : with  = in yamlencode

### DIFF
--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -12,53 +12,53 @@ resource "helm_release" "k8s-service" {
   name  = "${var.layer_name}-${var.module_name}"
   values = [
     yamlencode({
-      deployment_timestamp : timestamp()
-      autoscaling : {
-        minReplicas : var.min_containers,
-        maxReplicas : var.max_containers,
-        targetCPUUtilizationPercentage : var.autoscaling_target_cpu_percentage
-        targetMemoryUtilizationPercentage : var.autoscaling_target_mem_percentage
+      deployment_timestamp = timestamp()
+      autoscaling = {
+        minReplicas = var.min_containers,
+        maxReplicas = var.max_containers,
+        targetCPUUtilizationPercentage = var.autoscaling_target_cpu_percentage
+        targetMemoryUtilizationPercentage = var.autoscaling_target_mem_percentage
       },
-      httpPort : var.http_port,
-      probePort : var.probe_port,
-      ports : var.ports,
-      serviceAnnotations : var.service_annotations,
-      containerResourceLimits : {
-        memory : var.resource_limits == null ? "${var.resource_request["memory"] * 2}Mi" : "${var.resource_limits["memory"]}Mi"
+      httpPort = var.http_port,
+      probePort = var.probe_port,
+      ports = var.ports,
+      serviceAnnotations = var.service_annotations,
+      containerResourceLimits = {
+        memory = var.resource_limits == null ? "${var.resource_request["memory"] * 2}Mi" = "${var.resource_limits["memory"]}Mi"
       },
-      containerResourceRequests : {
-        cpu : "${var.resource_request["cpu"]}m"
-        memory : "${var.resource_request["memory"]}Mi"
+      containerResourceRequests = {
+        cpu = "${var.resource_request["cpu"]}m"
+        memory = "${var.resource_request["memory"]}Mi"
       },
-      deployPods : (local.uppercase_image != "AUTO") || (var.tag != null) || (var.digest != null),
-      image : local.image
-      version : var.tag == null ? "latest" : var.tag
-      livenessProbePath : var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path : var.healthcheck_path,
-      livenessProbeCommand : length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command : var.healthcheck_command,
-      initialLivenessDelay : var.initial_liveness_delay
-      readinessProbePath : var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path : var.healthcheck_path,
-      readinessProbeCommand : length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command : var.healthcheck_command,
-      initialReadinessDelay : var.initial_readiness_delay
-      healthcheck_path : var.healthcheck_path,
-      envVars : var.env_vars,
-      linkSecrets : var.link_secrets,
-      uriComponents : local.uri_components,
-      layerName : var.layer_name,
-      moduleName : var.module_name,
-      environmentName : var.env_name,
-      iamRoleArn : aws_iam_role.k8s_service.arn
-      stickySession : var.sticky_session
-      stickySessionMaxAge : var.sticky_session_max_age
-      consistentHash : var.consistent_hash
-      keepPathPrefix : var.keep_path_prefix
-      persistentStorage : var.persistent_storage
-      ingressExtraAnnotations : var.ingress_extra_annotations
-      tolerations : var.tolerations
-      cron_jobs : var.cron_jobs
-      podAnnotations : var.pod_annotations
-      podLabels : var.pod_labels
-      commands : var.commands
-      args : var.args
+      deployPods = (local.uppercase_image != "AUTO") || (var.tag != null) || (var.digest != null),
+      image = local.image
+      version = var.tag == null ? "latest" = var.tag
+      livenessProbePath = var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path = var.healthcheck_path,
+      livenessProbeCommand = length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command = var.healthcheck_command,
+      initialLivenessDelay = var.initial_liveness_delay
+      readinessProbePath = var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path = var.healthcheck_path,
+      readinessProbeCommand = length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command = var.healthcheck_command,
+      initialReadinessDelay = var.initial_readiness_delay
+      healthcheck_path = var.healthcheck_path,
+      envVars = var.env_vars,
+      linkSecrets = var.link_secrets,
+      uriComponents = local.uri_components,
+      layerName = var.layer_name,
+      moduleName = var.module_name,
+      environmentName = var.env_name,
+      iamRoleArn = aws_iam_role.k8s_service.arn
+      stickySession = var.sticky_session
+      stickySessionMaxAge = var.sticky_session_max_age
+      consistentHash = var.consistent_hash
+      keepPathPrefix = var.keep_path_prefix
+      persistentStorage = var.persistent_storage
+      ingressExtraAnnotations = var.ingress_extra_annotations
+      tolerations = var.tolerations
+      cron_jobs = var.cron_jobs
+      podAnnotations = var.pod_annotations
+      podLabels = var.pod_labels
+      commands = var.commands
+      args = var.args
     })
   ]
   atomic          = true

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -14,38 +14,38 @@ resource "helm_release" "k8s-service" {
     yamlencode({
       deployment_timestamp = timestamp()
       autoscaling = {
-        minReplicas = var.min_containers,
-        maxReplicas = var.max_containers,
+        minReplicas = var.min_containers
+        maxReplicas = var.max_containers
         targetCPUUtilizationPercentage = var.autoscaling_target_cpu_percentage
         targetMemoryUtilizationPercentage = var.autoscaling_target_mem_percentage
-      },
-      httpPort = var.http_port,
-      probePort = var.probe_port,
-      ports = var.ports,
-      serviceAnnotations = var.service_annotations,
+      }
+      httpPort = var.http_port
+      probePort = var.probe_port
+      ports = var.ports
+      serviceAnnotations = var.service_annotations
       containerResourceLimits = {
         memory = var.resource_limits == null ? "${var.resource_request["memory"] * 2}Mi" : "${var.resource_limits["memory"]}Mi"
-      },
+      }
       containerResourceRequests = {
         cpu = "${var.resource_request["cpu"]}m"
         memory = "${var.resource_request["memory"]}Mi"
-      },
-      deployPods = (local.uppercase_image != "AUTO") || (var.tag != null) || (var.digest != null),
+      }
+      deployPods = (local.uppercase_image != "AUTO") || (var.tag != null) || (var.digest != null)
       image = local.image
       version = var.tag == null ? "latest" = var.tag
-      livenessProbePath = var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path : var.healthcheck_path,
-      livenessProbeCommand = length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command : var.healthcheck_command,
+      livenessProbePath = var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path : var.healthcheck_path
+      livenessProbeCommand = length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command : var.healthcheck_command
       initialLivenessDelay = var.initial_liveness_delay
-      readinessProbePath = var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path : var.healthcheck_path,
-      readinessProbeCommand = length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command : var.healthcheck_command,
+      readinessProbePath = var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path : var.healthcheck_path
+      readinessProbeCommand = length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command : var.healthcheck_command
       initialReadinessDelay = var.initial_readiness_delay
-      healthcheck_path = var.healthcheck_path,
-      envVars = var.env_vars,
-      linkSecrets = var.link_secrets,
-      uriComponents = local.uri_components,
-      layerName = var.layer_name,
-      moduleName = var.module_name,
-      environmentName = var.env_name,
+      healthcheck_path = var.healthcheck_path
+      envVars = var.env_vars
+      linkSecrets = var.link_secrets
+      uriComponents = local.uri_components
+      layerName = var.layer_name
+      moduleName = var.module_name
+      environmentName = var.env_name
       iamRoleArn = aws_iam_role.k8s_service.arn
       stickySession = var.sticky_session
       stickySessionMaxAge = var.sticky_session_max_age

--- a/modules/aws_k8s_service/tf_module/main.tf
+++ b/modules/aws_k8s_service/tf_module/main.tf
@@ -24,7 +24,7 @@ resource "helm_release" "k8s-service" {
       ports = var.ports,
       serviceAnnotations = var.service_annotations,
       containerResourceLimits = {
-        memory = var.resource_limits == null ? "${var.resource_request["memory"] * 2}Mi" = "${var.resource_limits["memory"]}Mi"
+        memory = var.resource_limits == null ? "${var.resource_request["memory"] * 2}Mi" : "${var.resource_limits["memory"]}Mi"
       },
       containerResourceRequests = {
         cpu = "${var.resource_request["cpu"]}m"
@@ -33,11 +33,11 @@ resource "helm_release" "k8s-service" {
       deployPods = (local.uppercase_image != "AUTO") || (var.tag != null) || (var.digest != null),
       image = local.image
       version = var.tag == null ? "latest" = var.tag
-      livenessProbePath = var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path = var.healthcheck_path,
-      livenessProbeCommand = length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command = var.healthcheck_command,
+      livenessProbePath = var.healthcheck_path == null || var.liveness_probe_path != null ? var.liveness_probe_path : var.healthcheck_path,
+      livenessProbeCommand = length(var.healthcheck_command) == 0 || length(var.liveness_probe_command) != 0 ? var.liveness_probe_command : var.healthcheck_command,
       initialLivenessDelay = var.initial_liveness_delay
-      readinessProbePath = var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path = var.healthcheck_path,
-      readinessProbeCommand = length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command = var.healthcheck_command,
+      readinessProbePath = var.healthcheck_path == null || var.readiness_probe_path != null ? var.readiness_probe_path : var.healthcheck_path,
+      readinessProbeCommand = length(var.healthcheck_command) == 0 || length(var.readiness_probe_command) != 0 ? var.readiness_probe_command : var.healthcheck_command,
       initialReadinessDelay = var.initial_readiness_delay
       healthcheck_path = var.healthcheck_path,
       envVars = var.env_vars,


### PR DESCRIPTION
# Description
Update yamlencode syntax. Based on my googling its unclear why this worked in this way previously, but this syntax is considered valid by yamllint locally

Chat GPT's explanation:


`yamlencode()` in Terraform has **never officially supported `:` as a key-value separator**. Terraform uses **HCL (HashiCorp Configuration Language)**, which requires `=` for key-value assignments inside objects and maps.

However, if you were using `:` in older versions of Terraform, it might have **worked accidentally** in certain contexts, but it was never a valid syntax for Terraform's HCL.

### **Why Does `yamlencode()` Not Support `:`?**
- `yamlencode()` converts **Terraform objects** into YAML.
- Terraform objects **must** use `=` to define key-value pairs.
- The correct syntax for HCL is:
  ```hcl
  my_map = {
    key1 = "value1",
    key2 = "value2"
  }
  ```
- Using `:` was **never valid** and would cause syntax errors in newer versions.

### **Possible Reasons You Saw It Work Before**
1. **Older Terraform Versions (Before 0.12) Allowed More Lenient Syntax**
   - Terraform **0.12 (Released in 2019)** introduced stricter syntax validation.
   - Before Terraform 0.12, HCL was more permissive and **may have tolerated `:` in certain cases**.
   - After Terraform 0.12, it enforced `=` for all key-value pairs.

2. **Different Context (Using YAML Directly, Not HCL)**
   - If you were writing YAML inside `file()` or `templatefile()`, then `:` was fine.
   - Example (YAML inside a file, not HCL):
     ```yaml
     key1: value1
     key2: value2
     ```
   - But inside `yamlencode()`, this needs to be a proper Terraform object with `=`.

3. **Possible Use of Legacy Terraform Parsers**
   - If you were using older versions of Terraform (e.g., 0.11 or earlier), HashiCorp's HCL parser may have allowed some cases of `:` without error.

### **Conclusion**
- **`yamlencode()` never officially supported `:`** in Terraform objects.
- If it worked before, it was likely **accidental or due to a different parsing mechanism**.
- **Terraform 0.12+ enforces `=` as the only valid key-value separator in HCL.**
- Always use `=` when defining objects in Terraform.

Let me know if you need further clarification! 🚀

# Safety checklist
* [ ] This change is backwards compatible and safe to apply by existing users
* [ ] This change will NOT lead to data loss
* [ ] This change will NOT lead to downtime who already has an env/service setup

## How has this change been tested, beside unit tests?
YOUR_ANSWER
